### PR TITLE
Add compute_admin_fee utility and unit tests for admin fee calculation

### DIFF
--- a/src/components/logics.cairo
+++ b/src/components/logics.cairo
@@ -1,3 +1,5 @@
+use core::integer::u256;
+
 #[starknet::component]
 pub mod LogicComponent {
     #[storage]
@@ -12,11 +14,11 @@ pub mod LogicComponent {
 /// Computes the admin fee from interest using basis points (bps).
 /// admin_fee = (interest * admin_fee_bps) / 10_000
 /// Handles zero values and uses safe u256 math.
-pub fn compute_admin_fee(interest: U256, admin_fee_bps: U256) -> U256 {
-    if interest == u256_zero() || admin_fee_bps == u256_zero() {
-        return u256_zero();
+pub fn compute_admin_fee(interest: u256, admin_fee_bps: u256) -> u256 {
+    if interest == 0_u256 || admin_fee_bps == 0_u256 {
+        return 0_u256;
     }
-    let (product, _) = u256_mul(interest, admin_fee_bps);
-    let (fee, _) = u256_div(product, U256::from_u32(10_000));
+    let product = interest * admin_fee_bps;
+    let fee = product / 10_000_u256;
     fee
 }

--- a/src/components/logics.cairo
+++ b/src/components/logics.cairo
@@ -8,3 +8,15 @@ pub mod LogicComponent {
         TContractState, +HasComponent<TContractState>,
     > of InternalTrait<TContractState> {}
 }
+
+/// Computes the admin fee from interest using basis points (bps).
+/// admin_fee = (interest * admin_fee_bps) / 10_000
+/// Handles zero values and uses safe u256 math.
+pub fn compute_admin_fee(interest: U256, admin_fee_bps: U256) -> U256 {
+    if interest == u256_zero() || admin_fee_bps == u256_zero() {
+        return u256_zero();
+    }
+    let (product, _) = u256_mul(interest, admin_fee_bps);
+    let (fee, _) = u256_div(product, U256::from_u32(10_000));
+    fee
+}

--- a/src/tests/test_utils.cairo
+++ b/src/tests/test_utils.cairo
@@ -1,6 +1,6 @@
+use core::integer::u256;
 use snforge_std::{ContractClassTrait, DeclareResultTrait, declare};
 use starknet::{ContractAddress, contract_address_const};
-use core::integer::u256;
 use crate::components::logics::compute_admin_fee;
 
 pub fn deploy_contract() -> (ContractAddress, ContractAddress) {

--- a/src/tests/test_utils.cairo
+++ b/src/tests/test_utils.cairo
@@ -10,3 +10,21 @@ pub fn deploy_contract() -> (ContractAddress, ContractAddress) {
 
     (contract_address, owner_address)
 }
+
+#[test]
+fn test_admin_fee_zero_interest() {
+    let interest = u256_from_u32(0);
+    let admin_fee_bps = u256_from_u32(500);
+    let expected = u256_from_u32(0);
+    let result = compute_admin_fee(interest, admin_fee_bps);
+    assert(result == expected, 'Zero interest failed');
+}
+
+#[test]
+fn test_admin_fee_zero_fee() {
+    let interest = u256_from_u32(100_000);
+    let admin_fee_bps = u256_from_u32(0);
+    let expected = u256_from_u32(0);
+    let result = compute_admin_fee(interest, admin_fee_bps);
+    assert(result == expected, 'Zero fee failed');
+}

--- a/src/tests/test_utils.cairo
+++ b/src/tests/test_utils.cairo
@@ -1,5 +1,7 @@
 use snforge_std::{ContractClassTrait, DeclareResultTrait, declare};
 use starknet::{ContractAddress, contract_address_const};
+use core::integer::u256;
+use crate::components::logics::compute_admin_fee;
 
 pub fn deploy_contract() -> (ContractAddress, ContractAddress) {
     let owner_address = contract_address_const::<'owner_address'>();
@@ -12,19 +14,37 @@ pub fn deploy_contract() -> (ContractAddress, ContractAddress) {
 }
 
 #[test]
+fn test_admin_fee_standard_percentage() {
+    let interest = 100_000_u256;
+    let admin_fee_bps = 500_u256; // 5%
+    let expected = 5_000_u256; // (100_000 * 500) / 10_000 = 5_000
+    let result = compute_admin_fee(interest, admin_fee_bps);
+    assert(result == expected, 'Standard percentage failed');
+}
+
+#[test]
+fn test_admin_fee_large_interest() {
+    let interest = u256 { low: 0, high: 1_000_000 };
+    let admin_fee_bps = 1000_u256; // 10%
+    let expected = u256 { low: 0, high: 100_000 };
+    let result = compute_admin_fee(interest, admin_fee_bps);
+    assert(result == expected, 'Large interest failed');
+}
+
+#[test]
 fn test_admin_fee_zero_interest() {
-    let interest = u256_from_u32(0);
-    let admin_fee_bps = u256_from_u32(500);
-    let expected = u256_from_u32(0);
+    let interest = 0_u256;
+    let admin_fee_bps = 500_u256;
+    let expected = 0_u256;
     let result = compute_admin_fee(interest, admin_fee_bps);
     assert(result == expected, 'Zero interest failed');
 }
 
 #[test]
 fn test_admin_fee_zero_fee() {
-    let interest = u256_from_u32(100_000);
-    let admin_fee_bps = u256_from_u32(0);
-    let expected = u256_from_u32(0);
+    let interest = 100_000_u256;
+    let admin_fee_bps = 0_u256;
+    let expected = 0_u256;
     let result = compute_admin_fee(interest, admin_fee_bps);
     assert(result == expected, 'Zero fee failed');
 }


### PR DESCRIPTION
# Summary of Changes

## 1. Added `compute_admin_fee` Utility Function
- **Location**: [`[logics.cairo](vscode-file://vscode-app/c:/Users/Dell/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-sandbox/workbench/workbench.html)`](vscode-file://vscode-app/c:/Users/Dell/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-sandbox/workbench/workbench.html)
- **Purpose**: Calculates the admin commission (protocol fee) from the interest earned on a loan, based on a percentage expressed in basis points (bps).

## 2. Unit Tests for `compute_admin_fee`
- **Location**: [`[test_utils.cairo](vscode-file://vscode-app/c:/Users/Dell/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-sandbox/workbench/workbench.html)`](vscode-file://vscode-app/c:/Users/Dell/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-sandbox/workbench/workbench.html)
- **Purpose**: Validates the correctness of the `compute_admin_fee` function across standard, large, and zero-value scenarios.

---

# How the Changes Meet the Requirements

## 1. Function Implementation

### Signature
- **Inputs**:
  - `interest`: Total interest earned (`u256`)
  - `admin_fee_bps`: Admin fee in basis points (`u256`)

- **Output**:
  - Returns the calculated admin fee as a `u256`.

### Formula and Safe Math
- Uses Cairo 1.x’s native `u256` type and arithmetic operators (`*`, `/`) to ensure correctness and prevent overflow with large values.

### Edge-Case Handling
- Returns **zero** if either `interest` or `admin_fee_bps` is zero.

---

## 2. Unit Test Coverage

- **Standard Percentages**:  
  Test with 500 bps (5%) and verify correct calculation.

- **Large Interest Values**:  
  Test with very large `u256` values to ensure no overflow and correct arithmetic.

- **Zero Values**:  
  Test with zero interest and/or zero fee to confirm the function returns zero.

Fixes #18 