### PR TITLE
Implement is_not_defaulted_loan functionality

### DIFF
--- a/src/components/operations.cairo
+++ b/src/components/operations.cairo
@@ -89,6 +89,20 @@ pub mod OperationsComponent {
 
             loan.status != LoanStatus::FORECLOSED && loan.status != LoanStatus::REPAID
         }
+
+        fn is_not_defaulted_loan(self: @ComponentState<TContractState>, loan_id: u256) -> bool {
+            if !self.is_valid_loan(loan_id) {
+                return false;
+            }
+
+            let loan = self.get_loan(loan_id);
+
+            let check = loan.loan_start_time + loan.loan_duration > get_block_timestamp();
+            if !check {
+                return false;
+            }
+            true
+        }
     }
 
     #[generate_trait]

--- a/src/interfaces/ioperations.cairo
+++ b/src/interfaces/ioperations.cairo
@@ -6,4 +6,5 @@ pub trait IOperations<TContractState> {
     fn is_active_loan(self: @TContractState, loan_id: u256) -> bool;
     fn is_valid_loan(self: @TContractState, loan_id: u256) -> bool;
     fn can_renegotiate_loan(self: @TContractState, loan_id: u256) -> bool;
+    fn is_not_defaulted_loan(self: @TContractState, loan_id: u256) -> bool;
 }

--- a/src/tests/test_operations.cairo
+++ b/src/tests/test_operations.cairo
@@ -2,7 +2,7 @@ use starknet::{ContractAddress};
 use starknet::storage::{StoragePointerWriteAccess, StoragePathEntry};
 use trajectfi::components::operations::OperationsComponent::{OperationsImpl};
 use trajectfi::types::{Loan, LoanStatus};
-use starknet::testing::set_block_timestamp;
+use snforge_std::{test_address, start_cheat_block_timestamp, stop_cheat_block_timestamp};
 
 
 #[test]
@@ -407,11 +407,11 @@ fn test_is_not_defaulted_loan() {
     // Setup test environment
     let mut state: MockOperationsContract::ContractState =
         MockOperationsContract::contract_state_for_testing();
+    let test_contract_address: ContractAddress = test_address();
 
     // Create loan directly in storage
     let loan_id = 1_u256;
     let time_stamp = 2000;
-    set_block_timestamp(time_stamp);
 
     // Create a valid loan
     let valid_loan = Loan {
@@ -432,10 +432,12 @@ fn test_is_not_defaulted_loan() {
     state.operations.loan_exists.entry(loan_id).write(true);
 
     // Set new timestamp to ensure check passes
-    set_block_timestamp(time_stamp + 2000);
+    start_cheat_block_timestamp(test_contract_address, time_stamp + 2000);
 
     // Check if the loan is valid
     assert(state.is_not_defaulted_loan(loan_id), 'should not be defaulted');
+
+    stop_cheat_block_timestamp(test_contract_address);
 }
 
 #[test]
@@ -447,7 +449,7 @@ fn test_is_not_defaulted_loan_defaulted() {
     // Create loan directly in storage
     let loan_id = 1_u256;
     let time_stamp = 2000;
-    set_block_timestamp(time_stamp);
+    let test_contract_address: ContractAddress = test_address();
 
     // Create a valid loan
     let valid_loan = Loan {
@@ -468,8 +470,10 @@ fn test_is_not_defaulted_loan_defaulted() {
     state.operations.loan_exists.entry(loan_id).write(true);
 
     // Set new timestamp to ensure check fails
-    set_block_timestamp(time_stamp + 90000);
+    start_cheat_block_timestamp(test_contract_address, time_stamp + 90000);
 
     // Check if the loan is valid
     assert(!state.is_not_defaulted_loan(loan_id), 'should be defaulted');
+
+    stop_cheat_block_timestamp(test_contract_address);
 }

--- a/src/trajectfi.cairo
+++ b/src/trajectfi.cairo
@@ -11,6 +11,7 @@ pub mod Trajectfi {
     use trajectfi::components::admin::AdminComponent;
     use trajectfi::components::logics::LogicComponent;
     use trajectfi::components::signing::SigningComponent;
+    use trajectfi::components::operations::OperationsComponent;
     use trajectfi::interfaces::itrajectfi::ITrajectfi;
     use trajectfi::types::{ADMIN_ROLE, OWNER_ROLE};
 
@@ -25,6 +26,7 @@ pub mod Trajectfi {
 
     component!(path: LogicComponent, storage: logics_storage, event: LogicComponentEvent);
     component!(path: SigningComponent, storage: signing_storage, event: SigningComponentEvent);
+    component!(path: OperationsComponent, storage: operations_storage, event: OperationsEvent);
     component!(path: ERC721Component, storage: erc721, event: ERC721Event);
     component!(path: SRC5Component, storage: src5, event: SRC5Event);
 
@@ -78,6 +80,8 @@ pub mod Trajectfi {
         logics_storage: LogicComponent::Storage,
         #[substorage(v0)]
         signing_storage: SigningComponent::Storage,
+        #[substorage(v0)]
+        operations_storage: OperationsComponent::Storage,
     }
 
     #[event]
@@ -103,6 +107,8 @@ pub mod Trajectfi {
         LogicComponentEvent: LogicComponent::Event,
         #[flat]
         SigningComponentEvent: SigningComponent::Event,
+        #[flat]
+        OperationsEvent: OperationsComponent::Event,
     }
 
     #[constructor]


### PR DESCRIPTION
## Description
This PR implement the is_not_defaulted_loan functionality. the functionality checks whether a loan is still active and not defaulted. This function builds on top of is_valid_loan and adds a time-based check to ensure that the loan has not passed its repayment deadline

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Configuration change


## Checklist

### Development Best Practices

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] New and existing tests pass locally with my changes


### Testing

- [x] Unit tests cover the new functionality
- [x] Integration tests verify the changes work with other components


## Related Issues

<!--
Link any related issues or tickets from your issue tracker.
e.g., Fixes #123
-->
Fixes #27 

