### PR TITLE
 Add Offer Management to Market Component

### DIFF
--- a/src/components/market.cairo
+++ b/src/components/market.cairo
@@ -67,12 +67,14 @@ pub mod MarketComponent {
             loan_duration: u64,
         ) {}
         fn accept_offer(
-            ref self: ComponentState<TContractState>,
-            listing_id: u256,
-            offer_id: u256,
+            ref self: ComponentState<TContractState>, listing_id: u256, offer_id: u256,
         ) {}
-        fn close_offer(ref self: ComponentState<TContractState>, listing_id: u256, offer_id: u256) {}
-        fn get_offer(self: @ComponentState<TContractState>, listing_id: u256, offer_id: u256) -> Offer {
+        fn close_offer(
+            ref self: ComponentState<TContractState>, listing_id: u256, offer_id: u256
+        ) {}
+        fn get_offer(
+            self: @ComponentState<TContractState>, listing_id: u256, offer_id: u256
+        ) -> Offer {
             Offer {
                 id: 0,
                 listing_id: listing_id,
@@ -90,11 +92,15 @@ pub mod MarketComponent {
                 updated_at: 0,
             }
         }
-        fn get_offers(self: @ComponentState<TContractState>, listing_id: u256, offer_id: u256) -> Array<Offer> {
+        fn get_offers(
+            self: @ComponentState<TContractState>, listing_id: u256, offer_id: u256
+        ) -> Array<Offer> {
             let offers: Array<Offer> = array![];
             offers
         }
-        fn get_open_offers(self: @ComponentState<TContractState>, listing_id: u256, offer_id: u256) -> Array<Offer> {
+        fn get_open_offers(
+            self: @ComponentState<TContractState>, listing_id: u256, offer_id: u256
+        ) -> Array<Offer> {
             let offers: Array<Offer> = array![];
             offers
         }

--- a/src/components/market.cairo
+++ b/src/components/market.cairo
@@ -2,7 +2,7 @@
 pub mod MarketComponent {
     use starknet::storage::{Map};
     use starknet::ContractAddress;
-    use trajectfi::types::{Listing, ListingStatus};
+    use trajectfi::types::{Listing, ListingStatus, Offer, OfferStatus};
     use trajectfi::interfaces::imarket::IMarket;
 
     #[storage]
@@ -56,6 +56,47 @@ pub mod MarketComponent {
         ) -> Array<Listing> {
             let listings: Array<Listing> = array![];
             listings
+        }
+        fn make_offer(
+            ref self: ComponentState<TContractState>,
+            listing_id: u256,
+            token_contract: ContractAddress,
+            token_amount: u256,
+            borrow_amount: u256,
+            repayment_amount: u256,
+            loan_duration: u64,
+        ) {}
+        fn accept_offer(
+            ref self: ComponentState<TContractState>,
+            listing_id: u256,
+            offer_id: u256,
+        ) {}
+        fn close_offer(ref self: ComponentState<TContractState>, listing_id: u256, offer_id: u256) {}
+        fn get_offer(self: @ComponentState<TContractState>, listing_id: u256, offer_id: u256) -> Offer {
+            Offer {
+                id: 0,
+                listing_id: listing_id,
+                borrower: 0.try_into().unwrap(),
+                nft_contract: 0.try_into().unwrap(),
+                nft_id: 0,
+                token_contract: 0.try_into().unwrap(),
+                token_amount: 0,
+                borrow_amount: 0,
+                repayment_amount: 0,
+                loan_duration: 0,
+                status: OfferStatus::OPEN,
+                offer_expiration: 0,
+                created_at: 0,
+                updated_at: 0,
+            }
+        }
+        fn get_offers(self: @ComponentState<TContractState>, listing_id: u256, offer_id: u256) -> Array<Offer> {
+            let offers: Array<Offer> = array![];
+            offers
+        }
+        fn get_open_offers(self: @ComponentState<TContractState>, listing_id: u256, offer_id: u256) -> Array<Offer> {
+            let offers: Array<Offer> = array![];
+            offers
         }
     }
 

--- a/src/interfaces/imarket.cairo
+++ b/src/interfaces/imarket.cairo
@@ -27,7 +27,7 @@ pub trait IMarket<TContractState> {
         token_amount: u256,
         borrow_amount: u256,
         repayment_amount: u256,
-        loan_duration: u64        
+        loan_duration: u64
     );
     fn accept_offer(ref self: TContractState, listing_id: u256, offer_id: u256);
     fn close_offer(ref self: TContractState, listing_id: u256, offer_id: u256);

--- a/src/interfaces/imarket.cairo
+++ b/src/interfaces/imarket.cairo
@@ -1,5 +1,5 @@
 use starknet::ContractAddress;
-use trajectfi::types::Listing;
+use trajectfi::types::{Listing, Offer};
 
 #[starknet::interface]
 pub trait IMarket<TContractState> {
@@ -20,4 +20,18 @@ pub trait IMarket<TContractState> {
     fn get_listings_by_token(
         self: @TContractState, token_contract: ContractAddress
     ) -> Array<Listing>;
+    fn make_offer(
+        ref self: TContractState,
+        listing_id: u256,
+        token_contract: ContractAddress,
+        token_amount: u256,
+        borrow_amount: u256,
+        repayment_amount: u256,
+        loan_duration: u64        
+    );
+    fn accept_offer(ref self: TContractState, listing_id: u256, offer_id: u256);
+    fn close_offer(ref self: TContractState, listing_id: u256, offer_id: u256);
+    fn get_offer(self: @TContractState, listing_id: u256, offer_id: u256) -> Offer;
+    fn get_offers(self: @TContractState, listing_id: u256, offer_id: u256) -> Array<Offer>;
+    fn get_open_offers(self: @TContractState, listing_id: u256, offer_id: u256) -> Array<Offer>;
 }

--- a/src/types.cairo
+++ b/src/types.cairo
@@ -67,3 +67,29 @@ pub struct Listing {
     pub created_at: u64,
     pub updated_at: u64,
 }
+
+#[derive(Copy, Drop, PartialEq, Serde, starknet::Store)]
+pub enum OfferStatus {
+    OPEN,
+    ACCEPTED,
+    CLOSED,
+    REJECTED
+}
+
+#[derive(Copy, Drop, Serde, starknet::Store)]
+pub struct Offer {
+    pub id: u256,
+    pub listing_id: u256,
+    pub borrower: ContractAddress,
+    pub nft_contract: ContractAddress,
+    pub nft_id: u256,
+    pub token_contract: ContractAddress,
+    pub token_amount: u256,
+    pub borrow_amount: u256,
+    pub repayment_amount: u256,
+    pub loan_duration: u64,
+    pub offer_expiration: u64,
+    pub status: OfferStatus,
+    pub created_at: u64,
+    pub updated_at: u64,
+}


### PR DESCRIPTION
### Summary
Introduce offer management to the market module by defining offer data structures, extending the market interface with offer-related APIs, and adding template implementations in the market component. Also includes minor formatting cleanups.

### Key Changes
- **Data types**:
  - Added `Offer` and `OfferStatus` in `src/types.cairo`.
- **Interface**:
  - Extended `IMarket` in `src/interfaces/imarket.cairo` with offer APIs:
    - `make_offer`, `accept_offer`, `close_offer`, `get_offer`, `get_offers`, `get_open_offers`.
- **Component**:
  - Implemented template/stub functions for offer management in `src/components/market.cairo`:
    - Added the above offer methods with placeholder logic and default return values.
  - Updated imports to include `Offer` and `OfferStatus`.
- **Chore**:
  - Formatting updates to `market.cairo` and `imarket.cairo`.

#### Files Changed
- Modified: `src/components/market.cairo`
- Modified: `src/interfaces/imarket.cairo`
- Modified: `src/types.cairo`

#### Notes
- Current implementations are templates/stubs to scaffold the offer flow; storage and state transitions for offers are not yet wired.
- No breaking changes; all changes are additive.

#### Testing
- No functional logic added yet; follow-up PR will add storage, state transitions, and tests for offer lifecycle.
